### PR TITLE
Fix typo in status comment

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -171,6 +171,6 @@ def stop():
 
 @APP.get("/api/status")
 def status():
-    # son ~50 log satiri dondur.
+    # son ~50 log satiri döndür.
     tail = STATE["log"][-50:]
     return {"running": STATE["running"], "progress": STATE.get("progress"), "logTail": tail}


### PR DESCRIPTION
## Summary
- replace typo "dondur" with "döndür" in status log comment

## Testing
- `python -m py_compile backend/main.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aa4e1e027c83339252d0ae27cc6bea