### PR TITLE
fix: update types filter comment

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -99,7 +99,7 @@ async def download_worker(cfg:Config):
             if max_d and (msg.date.replace(tzinfo=None) > max_d): 
                 continue
 
-            # types filter (sadece foto/video/doc)
+            # types filter (sadece photos/videos/documents)
             kind = None
             if msg.photo and "photos" in cfg.types:
                 kind = "photos"


### PR DESCRIPTION
## Summary
- clarify types filter comment for photos/videos/documents

## Testing
- `python -m py_compile backend/main.py`


------
https://chatgpt.com/codex/tasks/task_e_68aa4e2e3e708333903ddca76840fefa