### PR TITLE
chore: add service logging config and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,9 @@
 
 ### Logrotate
 `deploy/logrotate/telegramsaver` dosyasını `/etc/logrotate.d/` klasörüne kopyalayarak log dosyalarının otomatik döndürülmesini sağlayabilirsiniz.
+
+### Doğrulama
+Konfigürasyon dosyalarını test etmek için:
+```bash
+bash deploy/tests/test_service_scripts.sh
+```

--- a/deploy/telegramsaver.service
+++ b/deploy/telegramsaver.service
@@ -5,12 +5,13 @@ After=network.target
 [Service]
 Type=simple
 WorkingDirectory=%h/telegramsaverbotbeta
+Environment=LOG_DIR=%h/telegramsaverbotbeta/log
 ExecStart=/usr/bin/pm2 start deploy/ecosystem.config.js --no-daemon
 ExecReload=/usr/bin/pm2 reload all
 ExecStop=/usr/bin/pm2 stop all
 Restart=always
-StandardOutput=append:%h/telegramsaverbotbeta/log/telegramsaver.log
-StandardError=append:%h/telegramsaverbotbeta/log/telegramsaver.err.log
+StandardOutput=append:${LOG_DIR}/telegramsaver.log
+StandardError=append:${LOG_DIR}/telegramsaver.err.log
 
 [Install]
 WantedBy=multi-user.target

--- a/deploy/tests/test_service_scripts.sh
+++ b/deploy/tests/test_service_scripts.sh
@@ -8,7 +8,9 @@ LOGROTATE_FILE="$(dirname "$0")/../logrotate/telegramsaver"
 # Check systemd service file
 [ -f "$SERVICE_FILE" ]
 grep -q 'ExecStart=/usr/bin/pm2 start' "$SERVICE_FILE"
-grep -q 'log/telegramsaver.log' "$SERVICE_FILE"
+grep -q 'Environment=LOG_DIR=%h/telegramsaverbotbeta/log' "$SERVICE_FILE"
+grep -q 'StandardOutput=append:${LOG_DIR}/telegramsaver.log' "$SERVICE_FILE"
+grep -q 'StandardError=append:${LOG_DIR}/telegramsaver.err.log' "$SERVICE_FILE"
 
 # Check PM2 config
 [ -f "$PM2_FILE" ]


### PR DESCRIPTION
## Summary
- add LOG_DIR variable in systemd service for cleaner log routing
- document service setup and validation in README
- verify service, PM2, and logrotate configs with script

## Testing
- `bash deploy/tests/test_service_scripts.sh`


------
https://chatgpt.com/codex/tasks/task_e_68aa5e8ae63c8333b224b1cbe2c2f718