### PR TITLE
Ensure doctor.py builds pip path cross-platform

### DIFF
--- a/backend/doctor.py
+++ b/backend/doctor.py
@@ -35,7 +35,9 @@ if not VENV.exists():
     bad("Sanal ortam bulunamadi. Bir kez start_all.bat calistir.")
 else:
     ok("Sanal ortam var.")
-    pip = VENV / "Scripts" / "pip.exe"
+    bin_dir = "Scripts" if os.name == "nt" else "bin"
+    pip_name = "pip.exe" if os.name == "nt" else "pip"
+    pip = VENV / bin_dir / pip_name
     if pip.exists():
         print("\n[+] Paketler:")
         try:


### PR DESCRIPTION
## Summary
- Build pip path using os-specific bin directory and pip executable name

## Testing
- `python -m py_compile backend/doctor.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aa4ea810148333be2e9230e88c1c6b