### PR TITLE
Add tests for vc_escape escaping logic

### DIFF
--- a/tests/test_contacts.py
+++ b/tests/test_contacts.py
@@ -1,0 +1,16 @@
+import sys
+import pathlib
+import pytest
+
+# Add backend directory to path for module import
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "backend"))
+from contacts import vc_escape
+
+@pytest.mark.parametrize("input_value,expected", [
+    ("back\\slash", "back\\\\slash"),
+    ("semi;colon", "semi\\;colon"),
+    ("com,ma", "com\\,ma"),
+    ("line1\nline2", "line1\\nline2"),
+])
+def test_vc_escape(input_value, expected):
+    assert vc_escape(input_value) == expected


### PR DESCRIPTION
## Summary
- add pytest covering vc_escape for backslashes, semicolons, commas, and newlines

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa4e341a288333b8de15a78403d500