### PR TITLE
Fix media type comment in download filter

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -177,7 +177,7 @@ codex/wrap-download_worker-in-try/finally
                 if max_d and (msg.date.replace(tzinfo=None) > max_d):
                     continue
 
-                # types filter (sadece foto/video/doc)
+                # types filter (sadece photos/videos/documents)
                 kind = None
                 if msg.photo and "photos" in cfg.types:
                     kind = "photos"


### PR DESCRIPTION
## Summary
- clarify media type comment in `download_worker`

## Testing
- `pytest` *(fails: IndentationError in backend/tests/test_download_filters.py)*

------
https://chatgpt.com/codex/tasks/task_e_68aa646070cc833394138f92bb0f2cac