### PR TITLE
Fix React start script execution

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,8 +8,8 @@
     "react-scripts": "5.0.1"
   },
   "scripts": {
-    "start": "react-scripts start",
-    "test": "react-scripts test"
+    "start": "node node_modules/react-scripts/bin/react-scripts.js start",
+    "test": "node node_modules/react-scripts/bin/react-scripts.js test"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.1.5",


### PR DESCRIPTION
## Summary
- avoid permission issues by running react-scripts via node

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot find module '@testing-library/react')*
- `npm install` *(fails: 403 Forbidden for @testing-library/jest-dom)*

------
https://chatgpt.com/codex/tasks/task_e_68ab0717b5908333ace1dc512cb96b60