### PR TITLE
Document frontend API base and add env example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,24 @@
 # Telegram Archiver — One Click
 1) run-all.bat çift tık. 2) Panel: http://localhost:3000. 3) API ID/HASH gir → Kaydet → Başlat. 4) Kişiler sekmesi → Önizleme → VCF dışa aktar.
 
+## Frontend Environment
+
+The React frontend reads the backend URL from the `REACT_APP_API_BASE` variable.
+
+Examples:
+
+| Environment | Example Value |
+|-------------|---------------|
+| Local       | `http://127.0.0.1:8000` |
+| Production  | `https://api.example.com` |
+
+Before building or starting the frontend, copy the sample environment file and adjust the URL:
+
+```bash
+cp frontend/.env.example frontend/.env
+# edit frontend/.env and set REACT_APP_API_BASE as needed
+```
+
 ## Servis Kurulumu
 
 ### Systemd

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,1 @@
+REACT_APP_API_BASE=http://127.0.0.1:8000


### PR DESCRIPTION
## Summary
- document `REACT_APP_API_BASE` usage with local and production examples
- add `.env.example` with default API base URL

## Testing
- `pytest` (fails: SyntaxError in backend/tests/test_download_filters.py)
- `cd frontend && CI=true npm test` (fails: Cannot find module '@testing-library/react')

------
https://chatgpt.com/codex/tasks/task_e_68ab0ca250788333a1ee50b74bea3dcb