### PR TITLE
Clean download filter tests

### DIFF
--- a/backend/tests/test_download_filters.py
+++ b/backend/tests/test_download_filters.py
@@ -1,29 +1,15 @@
 import asyncio
 import datetime as dt
-codex/fix-all-issues-g5pt6z
-from types import SimpleNamespace
-from pathlib import Path
-
-main
 import sys
 from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
+from telethon import types as tl_types
 
 sys.path.append(str(Path(__file__).resolve().parents[2]))
 from backend import main
-codex/fix-all-issues-0zhom0
 from backend.main import Config
-from telethon import types, types as tl_types
-
-codex/fix-all-issues-g5pt6z
-
-from backend.main import Config
-from telethon import types
-from telethon import types as tl_types
-main
-main
 
 
 class FilterClient:
@@ -46,15 +32,7 @@ class FilterClient:
     async def iter_messages(self, dialog, reverse=True, filter=None):
         self.iter_calls.append((dialog.name, type(filter).__name__ if filter else None))
         now = dt.datetime.now()
-codex/fix-all-issues-g5pt6z
-        from telethon import types
-        if dialog.name == "chan1" and isinstance(filter, types.InputMessagesFilterPhotos):
-
-        if dialog.name == "chan1" and isinstance(filter, types.InputMessagesFilterPhotoVideo):
-main
-            yield SimpleNamespace(id=10, date=now, photo=True, file=SimpleNamespace(name="p.jpg"), media="loc")
-            yield SimpleNamespace(id=11, date=now, video=True, file=SimpleNamespace(name="v.mp4"), media="loc")
-        if dialog.name == "chan1" and isinstance(filter, types.InputMessagesFilterPhotoVideo):
+        if dialog.name == "chan1" and isinstance(filter, tl_types.InputMessagesFilterPhotoVideo):
             yield SimpleNamespace(id=10, date=now, photo=True, file=SimpleNamespace(name="p.jpg"), media="loc")
             yield SimpleNamespace(id=11, date=now, video=True, file=SimpleNamespace(name="v.mp4"), media="loc")
 
@@ -97,6 +75,9 @@ class DummyClient:
         for m in self.messages:
             yield m
 
+    async def download_media(self, msg, file=None):
+        pass
+
     async def download_file(self, media, file, offset=0):
         self.download_file_calls.append(offset)
         file.write(b"data")
@@ -118,11 +99,8 @@ def test_channel_and_media_filters(monkeypatch, tmp_path):
     cfg = Config(api_id="1", api_hash="h", out=str(tmp_path))
     asyncio.run(main.download_worker(cfg, channels=["chan1"], media_types=["photos", "videos"]))
     assert fake.iter_calls == [("chan1", "InputMessagesFilterPhotoVideo")]
-codex/fix-all-issues-0zhom0
     assert sorted(m[0] for m in calls) == [10, 11]
-
     assert len(calls) == 2
-main
 
 
 def test_download_resume(tmp_path):
@@ -135,49 +113,6 @@ def test_download_resume(tmp_path):
     asyncio.run(main.download_file(client, msg, tmp_path))
     full = tmp_path / "big.bin"
     assert full.exists() and full.stat().st_size == 2048
-codex/fix-all-issues-g5pt6z
-
-codex/fix-all-issues-0zhom0
-
-def test_photo_filter(monkeypatch, tmp_path):
-    msg = SimpleNamespace(id=1, date=dt.datetime(2024, 1, 1), photo=True, video=None, document=None,
-                          file=SimpleNamespace(size=10, name="a.jpg"))
-
-
-
-class DummyClient:
-    def __init__(self, messages):
-        self.messages = messages
-        self.iter_messages_filter = None
-        self.download_file_calls = []
-
-    async def connect(self):
-        pass
-
-    async def is_user_authorized(self):
-        return True
-
-    async def disconnect(self):
-        pass
-
-    async def iter_dialogs(self):
-        yield SimpleNamespace(id=1, name="chan1")
-
-    async def iter_messages(self, dialog, reverse=True, filter=None):
-        self.iter_messages_filter = filter
-        for m in self.messages:
-            yield m
-
-    async def download_media(self, msg, file=None):
-        pass
-
-    async def download_file(self, media, file, offset=0):
-        self.download_file_calls.append(offset)
-        file.write(b"data")
-
-
-async def _dummy_sleep(*args, **kwargs):
-    return None
 
 
 def test_photo_filter(monkeypatch, tmp_path):
@@ -189,7 +124,6 @@ def test_photo_filter(monkeypatch, tmp_path):
         document=None,
         file=SimpleNamespace(size=10, name="a.jpg"),
     )
-main
     client = DummyClient([msg])
     monkeypatch.setattr(main, "TelegramClient", lambda *a, **k: client)
     monkeypatch.setattr(main.asyncio, "sleep", _dummy_sleep)
@@ -199,10 +133,6 @@ main
 
 
 def test_photo_video_filter(monkeypatch, tmp_path):
-codex/fix-all-issues-0zhom0
-    msg = SimpleNamespace(id=1, date=dt.datetime(2024, 1, 1), photo=True, video=None, document=None,
-                          file=SimpleNamespace(size=10, name="a.jpg"))
-
     msg = SimpleNamespace(
         id=1,
         date=dt.datetime(2024, 1, 1),
@@ -211,7 +141,6 @@ codex/fix-all-issues-0zhom0
         document=None,
         file=SimpleNamespace(size=10, name="a.jpg"),
     )
-main
     client = DummyClient([msg])
     monkeypatch.setattr(main, "TelegramClient", lambda *a, **k: client)
     monkeypatch.setattr(main.asyncio, "sleep", _dummy_sleep)
@@ -221,11 +150,6 @@ main
 
 
 def test_document_filter(monkeypatch, tmp_path):
-codex/fix-all-issues-0zhom0
-    msg = SimpleNamespace(id=1, date=dt.datetime(2024, 1, 1), photo=None, video=None,
-                          document=SimpleNamespace(size=10, attributes=[SimpleNamespace(file_name="a.pdf")]),
-                          file=SimpleNamespace(size=10, name="a.pdf"))
-
     msg = SimpleNamespace(
         id=1,
         date=dt.datetime(2024, 1, 1),
@@ -234,7 +158,6 @@ codex/fix-all-issues-0zhom0
         document=SimpleNamespace(size=10, attributes=[SimpleNamespace(file_name="a.pdf")]),
         file=SimpleNamespace(size=10, name="a.pdf"),
     )
-main
     client = DummyClient([msg])
     monkeypatch.setattr(main, "TelegramClient", lambda *a, **k: client)
     monkeypatch.setattr(main.asyncio, "sleep", _dummy_sleep)
@@ -263,8 +186,3 @@ def test_large_file_resume(monkeypatch, tmp_path):
     asyncio.run(main.download_worker(cfg, channels=[1], media_types=["documents"]))
     assert client.download_file_calls == [5]
     assert (part_dir / "big.bin").exists()
-
-codex/fix-all-issues-0zhom0
-
-main
-main


### PR DESCRIPTION
## Summary
- remove codex markers and duplicate imports from download filter tests
- exercise photo, video, and document filters with dedicated test cases

## Testing
- `pytest backend/tests/test_download_filters.py::test_channel_and_media_filters -q`
- `pytest backend/tests/test_download_filters.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab0edfaac88333a345cd654a6083ae