### PR TITLE
Remove committed config and document setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ __pycache__/
 *.py[cod]
 *.session
 *.log
+
+backend/config.json

--- a/README.md
+++ b/README.md
@@ -1,6 +1,15 @@
 # Telegram Archiver — One Click
 1) run-all.bat çift tık. 2) Panel: http://localhost:3000. 3) API ID/HASH gir → Kaydet → Başlat. 4) Kişiler sekmesi → Önizleme → VCF dışa aktar.
 
+## Backend Configuration
+
+Backend ayarları `backend/config.json` dosyasında saklanır. Başlamadan önce örnek dosyayı kopyalayın ve düzenleyin:
+
+```bash
+cp backend/config.example.json backend/config.json
+# backend/config.json'u düzenleyip kendi Telegram API ID ve API HASH değerlerinizi girin
+```
+
 ## Frontend Environment
 
 The React frontend reads the backend URL from the `REACT_APP_API_BASE` variable.

--- a/README.txt
+++ b/README.txt
@@ -1,20 +1,23 @@
-
 Telegram Archiver — One‑Click (Windows)
 ======================================
 
-Bu klasörü **C:\Users\<kullanıcı>\Desktop** gibi basit bir yere çıkarın.
+Bu klasörü **C:\\Users\\<kullanıcı>\\Desktop** gibi basit bir yere çıkarın.
 
-1) İlk giriş (sadece bir kez):
+1) Konfigürasyon:
+   - `backend\\config.example.json` dosyasını `backend\\config.json` olarak kopyalayın.
+   - Dosyayı açıp kendi API ID ve API HASH değerlerinizi yazın.
+
+2) İlk giriş (sadece bir kez):
    - `login_once.bat` dosyasına çift tıkla.
    - Telefon numaranı gir, Telegram'ın gönderdiği kodu yaz (gerekirse 2FA şifren).
-   - `backend\tg_media.session` oluşur.
+   - `backend\\tg_media.session` oluşur.
 
-2) Başlat:
+3) Başlat:
    - `start_all.bat` dosyasına çift tıkla.
    - İki pencere açılır: **backend** (8000) ve **frontend** (3000).
    - Tarayıcı: http://localhost:3000
 
-3) Durdur:
+4) Durdur:
    - Açılan iki pencereyi kapatabilirsin.
    - veya `stop_all.bat` (deneyseldir) kullan.
 
@@ -22,5 +25,5 @@ Notlar
 ------
 - Scriptler, gerekirse otomatik olarak Python sanal ortamı kurar ve bağımlılıkları yükler.
 - Frontend tarafında `npm install` otomatik çalışır (Node.js gerekir).
-- Backend yapılandırması UI üzerinden yapılır ve `backend/config.json`’a yazılır.
+- Backend yapılandırması `backend/config.json`’da tutulur; örnek dosyayı kopyalayarak başlayın.
 - Hata durumunda `doctor.bat` ile test/onarım çalıştır.

--- a/backend/config.example.json
+++ b/backend/config.example.json
@@ -1,8 +1,8 @@
 {
-  "api_id": "28849275",
-  "api_hash": "d2677ac50fef8365d650bac93476bccc",
+  "api_id": "YOUR_API_ID",
+  "api_hash": "YOUR_API_HASH",
   "session": "tg_media",
-  "out": "d2677ac50fef8365d650bac93476bccc",
+  "out": "./downloads",
   "types": [
     "photos"
   ],


### PR DESCRIPTION
## Summary
- remove `backend/config.json` and provide `config.example.json`
- ignore `backend/config.json` in version control
- document how to create a config file for backend

## Testing
- `pytest` *(fails: SyntaxError: invalid decimal literal in backend/tests/test_download_filters.py)*

------
https://chatgpt.com/codex/tasks/task_e_68ab0edf28d88333ba4004e553c554c9