### PR TITLE
Fix syntax errors in frontend components

### DIFF
--- a/frontend/src/__tests__/SettingsForm.test.js
+++ b/frontend/src/__tests__/SettingsForm.test.js
@@ -1,47 +1,50 @@
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
 jest.mock('../services/api', () => ({
   fetchDialogs: jest.fn(() => Promise.resolve({ ok: true, data: [] }))
 }));
 
+import { fetchDialogs } from '../services/api';
 import SettingsForm from '../components/SettingsForm';
 import { AppContext } from '../context/AppContext';
 
 test('renders settings inputs', () => {
   const value = {
-codex/add-group-selection-list-feature-08lv7i
     cfg: { api_id: '', api_hash: '', session: '', out: '', types: [], dry_run: false, chats: [] },
     setField: () => {},
-    save: () => {}
-
-    cfg: { api_id:'', api_hash:'', session:'', out:'', types:[], dry_run:false },
-    setField: ()=>{},
-    save: ()=>{},
+    save: () => {},
     dialogs: [],
-main
+    setDialogs: () => {},
   };
   render(
     <AppContext.Provider value={value}>
-      <SettingsForm dialogs={[]} />
+      <SettingsForm />
     </AppContext.Provider>
   );
   expect(screen.getByLabelText(/API ID/i)).toBeInTheDocument();
   expect(screen.getByText(/Kaydet/)).toBeInTheDocument();
 });
 
-test('renders chat checkboxes', () => {
+test('renders chat checkboxes', async () => {
   const setField = jest.fn();
-  const value = { cfg: { chats: [] }, setField, save: ()=>{} };
   const dialogs = [{ id: 1, name: 'Group1' }, { id: 2, name: 'Group2' }];
+  fetchDialogs.mockResolvedValueOnce({ ok: true, data: dialogs });
+  const value = {
+    cfg: { chats: [] },
+    setField,
+    save: () => {},
+    dialogs: [],
+    setDialogs: () => {},
+  };
   render(
     <AppContext.Provider value={value}>
-      <SettingsForm dialogs={dialogs} />
+      <SettingsForm />
     </AppContext.Provider>
   );
-  const checkbox = screen.getByLabelText('Group1');
+  const checkbox = await screen.findByLabelText('Group1');
   expect(checkbox).toBeInTheDocument();
   fireEvent.click(checkbox);
-  expect(setField).toHaveBeenCalled();
+  await waitFor(() => expect(setField).toHaveBeenCalled());
 });

--- a/frontend/src/components/SettingsForm.js
+++ b/frontend/src/components/SettingsForm.js
@@ -1,18 +1,9 @@
-import React, { useContext, useEffect, useState } from 'react';
+import React, { useContext, useEffect } from 'react';
 import { AppContext } from '../context/AppContext';
 import { fetchDialogs } from '../services/api';
 
-codex/add-group-selection-list-feature-z3rqdr
-export default function SettingsForm(){
-codex/add-group-selection-list-feature-047pqy
-  const { cfg, dialogs, setField, save } = useContext(AppContext);
-
-  const { cfg, setField, save, dialogs } = useContext(AppContext);
-
-export default function SettingsForm({ dialogs = [] }){
-  const { cfg, setField, save } = useContext(AppContext);
-codex/add-group-selection-list-feature-08lv7i
-  const [dialogs, setDialogs] = useState([]);
+export default function SettingsForm() {
+  const { cfg, setField, save, dialogs, setDialogs } = useContext(AppContext);
 
   useEffect(() => {
     let alive = true;
@@ -23,12 +14,8 @@ codex/add-group-selection-list-feature-08lv7i
     return () => {
       alive = false;
     };
-  }, []);
+  }, [setDialogs]);
 
-
-main
-main
-main
   return (
     <>
       <div style={{display:'grid',gap:12,gridTemplateColumns:'1.3fr 1fr 1fr 1fr'}}>
@@ -42,52 +29,19 @@ main
         <div><label style={{fontSize:12,color:'#555'}}>Max Tarih</label><input type="date" value={cfg.max_date||""} onChange={e=>setField('max_date',e.target.value)} style={{width:'100%',padding:8,border:'1px solid #d0d0d0',borderRadius:10}}/></div>
       </div>
       <div style={{marginTop:12}}>
-codex/add-group-selection-list-feature-08lv7i
-        <label style={{fontSize:12,color:'#555'}}>Kanallar</label>
-        <div style={{display:'flex',flexDirection:'column',gap:4,maxHeight:200,overflowY:'auto',border:'1px solid #d0d0d0',padding:8,borderRadius:10}}>
-          {dialogs.map(d => (
-            <label key={d.id} style={{display:'flex',alignItems:'center',gap:6}}>
-              <input
-                type="checkbox"
-                checked={(cfg.chats || []).map(String).includes(String(d.id))}
-                onChange={e => {
-                  const set = new Set((cfg.chats || []).map(String));
-                  const id = String(d.id);
-                  if (e.target.checked) set.add(id); else set.delete(id);
-                  setField('chats', Array.from(set));
-
-codex/add-group-selection-list-feature-047pqy
         <label style={{fontSize:12,color:'#555',display:'block',marginBottom:4}}>Kanallar</label>
-        <div style={{maxHeight:200,overflowY:'auto',border:'1px solid #d0d0d0',borderRadius:10,padding:8}}>
-          {dialogs.map(d => (
-            <label key={d.id} style={{display:'flex',gap:6,alignItems:'center',marginBottom:4}}>
-              <input
-                type="checkbox"
-                checked={(cfg.chats||[]).includes(d.name)}
-                onChange={(e)=>{
-                  const s=new Set(cfg.chats||[]);
-                  if(e.target.checked) s.add(d.name); else s.delete(d.name);
-                  setField('chats',Array.from(s));
-
-codex/add-group-selection-list-feature-z3rqdr
-        <label style={{fontSize:12,color:'#555'}}>Kanallar</label>
-        <div style={{maxHeight:180,overflowY:'auto',padding:8,border:'1px solid #d0d0d0',borderRadius:10}}>
+        <div style={{maxHeight:200,overflowY:'auto',border:'1px solid #d0d0d0',borderRadius:10,padding:8,display:'flex',flexDirection:'column',gap:4}}>
           {dialogs.map(d => {
             const idStr = String(d.id);
-            const selected = (cfg.chats || []).includes(idStr) || (cfg.chats || []).includes(d.name);
+            const selected = (cfg.chats || []).map(String).includes(idStr);
             return (
-              <label key={idStr} style={{display:'flex',alignItems:'center',gap:6}}>
+              <label key={idStr} style={{display:'flex',gap:6,alignItems:'center'}}>
                 <input
                   type="checkbox"
                   checked={selected}
-                  onChange={e => {
+                  onChange={e=>{
                     const s = new Set((cfg.chats || []).map(String));
-                    if (e.target.checked) {
-                      s.add(idStr);
-                    } else {
-                      s.delete(idStr);
-                      s.delete(d.name);
-                    }
+                    if (e.target.checked) s.add(idStr); else s.delete(idStr);
                     setField('chats', Array.from(s));
                   }}
                 />
@@ -95,46 +49,20 @@ codex/add-group-selection-list-feature-z3rqdr
               </label>
             );
           })}
-
-        <label style={{fontSize:12,color:'#555',display:'block',marginBottom:4}}>Kanallar</label>
-        <div style={{maxHeight:200,overflowY:'auto',border:'1px solid #d0d0d0',borderRadius:10,padding:8,display:'flex',flexDirection:'column',gap:4}}>
-          {dialogs.map(d => (
-            <label key={d.id} style={{display:'inline-flex',gap:6,alignItems:'center'}}>
-              <input
-                type="checkbox"
-                checked={(cfg.chats||[]).includes(d.name)}
-                onChange={e=>{
-                  const s = new Set(cfg.chats||[]);
-                  if (e.target.checked) s.add(d.name); else s.delete(d.name);
-                  setField('chats', Array.from(s));
-main
-main
-                }}
-              />
-              <span>{d.name}</span>
-            </label>
-          ))}
-codex/add-group-selection-list-feature-08lv7i
-
-codex/add-group-selection-list-feature-047pqy
-          {dialogs.length===0 && (
+          {dialogs.length === 0 && (
             <div style={{fontSize:12,color:'#999'}}>Kanal bulunamadı</div>
           )}
-
-main
-main
-main
         </div>
       </div>
       <div style={{display:'flex',gap:16,alignItems:'center',marginTop:12,flexWrap:'wrap'}}>
         {['photos','videos','documents'].map(t=> (
           <label key={t} style={{display:'inline-flex',gap:6,alignItems:'center'}}>
-            <input type="checkbox" checked={(cfg.types||[]).includes(t)} onChange={(e)=>{const s=new Set(cfg.types||[]); if(e.target.checked)s.add(t); else s.delete(t); setField('types',Array.from(s));}}/>
+            <input type="checkbox" checked={(cfg.types||[]).includes(t)} onChange={e=>{const s=new Set(cfg.types||[]); if(e.target.checked)s.add(t); else s.delete(t); setField('types',Array.from(s));}}/>
             <span>{t}</span>
           </label>
         ))}
         <label style={{display:'inline-flex',gap:6,alignItems:'center'}}>
-          <input type="checkbox" checked={!!cfg.dry_run} onChange={(e)=>setField('dry_run',e.target.checked)}/>
+          <input type="checkbox" checked={!!cfg.dry_run} onChange={e=>setField('dry_run',e.target.checked)}/>
           <span>Dry-run</span>
         </label>
         <div style={{marginLeft:'auto'}}><button onClick={save}>Kaydet</button></div>

--- a/frontend/src/context/AppContext.js
+++ b/frontend/src/context/AppContext.js
@@ -5,19 +5,19 @@ import { fetchConfig, saveConfig, startRun, stopRun, fetchStatus } from '../serv
 export const AppContext = createContext();
 
 const defaultCfg = {
-  api_id: "",
-  api_hash: "",
-  session: "tg_media",
-  out: "C:/TelegramArchive",
-  types: ["photos"],
+  api_id: '',
+  api_hash: '',
+  session: 'tg_media',
+  out: 'C:/TelegramArchive',
+  types: ['photos'],
   chats: [],
   include: [],
   exclude: [],
-  min_date: "",
-  max_date: "",
+  min_date: '',
+  max_date: '',
   throttle: 0.2,
   concurrency: 3,
-  dry_run: false
+  dry_run: false,
 };
 
 const defaultProgress = { chat: '', downloaded: 0, skipped: 0 };
@@ -68,8 +68,7 @@ export function AppProvider({ children }) {
             const s = r.data || {};
             setRunning(!!s.running);
             setProgress(s.progress || defaultProgress);
-            if (Array.isArray(s.logTail))
-              setLog(p => [...p, ...s.logTail].slice(-400));
+            if (Array.isArray(s.logTail)) setLog(p => [...p, ...s.logTail].slice(-400));
           } else if (r.error) {
             setError(r.error.message || 'Durum alınamadı');
           }
@@ -85,7 +84,6 @@ export function AppProvider({ children }) {
 
   return (
     <AppContext.Provider
-codex/add-group-selection-list-feature-047pqy
       value={{
         cfg,
         setField,
@@ -100,12 +98,8 @@ codex/add-group-selection-list-feature-047pqy
         dialogs,
         setDialogs,
       }}
-
-      value={{ cfg, setField, save, start, stop, running, progress, log, clearLog, error, dialogs, setDialogs }}
-main
     >
       {children}
     </AppContext.Provider>
   );
 }
-


### PR DESCRIPTION
## Summary
- Clean `SettingsForm` to fetch dialogs and render channel selection without syntax errors
- Restore `AppContext` provider with proper value object
- Update settings form tests

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot find module '@testing-library/react')*

------
https://chatgpt.com/codex/tasks/task_e_68ab1ddf338883338afcbb723ade6c47