### PR TITLE
Fix broken React context and settings form

### DIFF
--- a/frontend/src/components/SettingsForm.js
+++ b/frontend/src/components/SettingsForm.js
@@ -1,13 +1,6 @@
-codex/fix-syntax-errors-in-components-ei8dp2
-import React, { useContext } from 'react';
-
 import React, { useContext, useEffect } from 'react';
-main
 import { AppContext } from '../context/AppContext';
-
-codex/fix-syntax-errors-in-components-ei8dp2
-export default function SettingsForm(){
-  const { cfg, setField, save, dialogs } = useContext(AppContext);
+import { fetchDialogs } from '../services/api';
 
 export default function SettingsForm() {
   const { cfg, setField, save, dialogs, setDialogs } = useContext(AppContext);
@@ -23,7 +16,6 @@ export default function SettingsForm() {
     };
   }, [setDialogs]);
 
-main
   return (
     <>
       <div style={{display:'grid',gap:12,gridTemplateColumns:'1.3fr 1fr 1fr 1fr'}}>
@@ -37,13 +29,8 @@ main
         <div><label style={{fontSize:12,color:'#555'}}>Max Tarih</label><input type="date" value={cfg.max_date||""} onChange={e=>setField('max_date',e.target.value)} style={{width:'100%',padding:8,border:'1px solid #d0d0d0',borderRadius:10}}/></div>
       </div>
       <div style={{marginTop:12}}>
-codex/fix-syntax-errors-in-components-ei8dp2
-        <label style={{fontSize:12,color:'#555'}}>Kanallar</label>
-        <div style={{maxHeight:180,overflowY:'auto',padding:8,border:'1px solid #d0d0d0',borderRadius:10}}>
-
         <label style={{fontSize:12,color:'#555',display:'block',marginBottom:4}}>Kanallar</label>
         <div style={{maxHeight:200,overflowY:'auto',border:'1px solid #d0d0d0',borderRadius:10,padding:8,display:'flex',flexDirection:'column',gap:4}}>
-main
           {dialogs.map(d => {
             const idStr = String(d.id);
             const selected = (cfg.chats || []).map(String).includes(idStr);
@@ -62,12 +49,9 @@ main
               </label>
             );
           })}
-codex/fix-syntax-errors-in-components-ei8dp2
-
           {dialogs.length === 0 && (
             <div style={{fontSize:12,color:'#999'}}>Kanal bulunamadı</div>
           )}
-main
         </div>
       </div>
       <div style={{display:'flex',gap:16,alignItems:'center',marginTop:12,flexWrap:'wrap'}}>

--- a/frontend/src/context/AppContext.js
+++ b/frontend/src/context/AppContext.js
@@ -84,9 +84,6 @@ export function AppProvider({ children }) {
 
   return (
     <AppContext.Provider
-codex/fix-syntax-errors-in-components-ei8dp2
-      value={{ cfg, setField, save, start, stop, running, progress, log, clearLog, error, dialogs, setDialogs }}
-
       value={{
         cfg,
         setField,
@@ -101,7 +98,6 @@ codex/fix-syntax-errors-in-components-ei8dp2
         dialogs,
         setDialogs,
       }}
-main
     >
       {children}
     </AppContext.Provider>


### PR DESCRIPTION
## Summary
- remove stray annotations and duplicate code in SettingsForm
- clean up AppContext provider value

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot find module '@testing-library/react'; SyntaxError in SettingsForm.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68ab2240e18083339c6675e02b0a85c5