### PR TITLE
Upgrade to Pydantic v2 for compatibility

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -92,13 +92,17 @@ def load_cfg() -> Config:
 
 
 def save_cfg(cfg: Config) -> None:
-    CFG_FILE.write_text(cfg.json(indent=2), encoding="utf-8")
+    if hasattr(cfg, "model_dump_json"):
+        CFG_FILE.write_text(cfg.model_dump_json(indent=2), encoding="utf-8")
+    else:  # pragma: no cover - fallback for Pydantic v1
+        CFG_FILE.write_text(cfg.json(indent=2), encoding="utf-8")
     STATE["config"] = cfg
 
 
 @APP.get("/api/config")
 def get_config():
-    return load_cfg().dict()
+    cfg = load_cfg()
+    return cfg.model_dump() if hasattr(cfg, "model_dump") else cfg.dict()  # pragma: no cover
 
 
 @APP.post("/api/config")

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,7 +1,7 @@
 fastapi==0.110.0
 uvicorn[standard]==0.29.0
 telethon==1.33.1
-pydantic==1.10.13
+pydantic==2.6.4
 watchfiles==0.20.0
 websockets==10.4
 rsa==4.9


### PR DESCRIPTION
## Summary
- Upgrade backend to Pydantic v2 and adjust requirements
- Use `model_dump` and `model_dump_json` with fallback for older Pydantic

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab26659ebc8333bd01ccea9308aeee