### PR TITLE
Add FAQ tab with contact email

### DIFF
--- a/frontend/src/__tests__/FaqSection.test.js
+++ b/frontend/src/__tests__/FaqSection.test.js
@@ -1,0 +1,9 @@
+import { render, screen } from '@testing-library/react';
+import FaqSection from '../components/FaqSection';
+
+test('shows FAQ heading and contact email', () => {
+  render(<FaqSection />);
+  expect(screen.getByText(/Sıkça Sorulan Sorular/i)).toBeInTheDocument();
+  const link = screen.getByRole('link', { name: /admin@zyvaarch.com/i });
+  expect(link).toHaveAttribute('href', 'mailto:admin@zyvaarch.com');
+});

--- a/frontend/src/components/ControlPanel.js
+++ b/frontend/src/components/ControlPanel.js
@@ -1,12 +1,14 @@
-import React, { useContext, useEffect } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import SettingsForm from './SettingsForm';
 import StatusPanel from './StatusPanel';
 import LogViewer from './LogViewer';
+import FaqSection from './FaqSection';
 import { AppContext } from '../context/AppContext';
 import { fetchDialogs } from '../services/api';
 
 export default function ControlPanel(){
   const { error, setDialogs } = useContext(AppContext);
+  const [tab, setTab] = useState('panel');
 
   useEffect(() => {
     fetchDialogs().then(r => {
@@ -18,14 +20,24 @@ export default function ControlPanel(){
   return (
     <div style={{maxWidth:1100,margin:'24px auto',padding:'0 16px'}}>
       <h1 style={{fontSize:22,margin:0,marginBottom:12}}>Telegram Arşivleyici — Kontrol Paneli</h1>
+      <div style={{display:'flex',gap:8,marginBottom:12}}>
+        <button onClick={()=>setTab('panel')}>Kontrol Paneli</button>
+        <button onClick={()=>setTab('faq')}>SSS</button>
+      </div>
       {error && (
         <div style={{background:'#f8d7da',border:'1px solid #f5c2c7',borderRadius:10,padding:10,marginBottom:12}}>
           {error}
         </div>
       )}
-      <SettingsForm />
-      <StatusPanel />
-      <LogViewer />
+      {tab === 'panel' ? (
+        <>
+          <SettingsForm />
+          <StatusPanel />
+          <LogViewer />
+        </>
+      ) : (
+        <FaqSection />
+      )}
     </div>
   );
 }

--- a/frontend/src/components/FaqSection.js
+++ b/frontend/src/components/FaqSection.js
@@ -1,0 +1,11 @@
+import React from 'react';
+
+export default function FaqSection(){
+  return (
+    <div style={{marginTop:24}}>
+      <h2 style={{fontSize:20,marginTop:0}}>Sıkça Sorulan Sorular</h2>
+      <p>Bu sistem hakkında geri bildirimde bulunmak veya bilgi almak için aşağıdaki adrese e-posta gönderebilirsiniz:</p>
+      <p><a href="mailto:admin@zyvaarch.com">admin@zyvaarch.com</a></p>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add dedicated FAQ tab to panel
- show feedback email link for contact
- include unit test for FAQ rendering

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot find module '@testing-library/react')*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab26bb09988333ad5fb28a0e3e39f3