### PR TITLE
Add minimal desktop UI components

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,18 @@ cp frontend/.env.example frontend/.env
 # edit frontend/.env and set REACT_APP_API_BASE as needed
 ```
 
+## Masaüstü Uygulaması
+
+Frontend'i masaüstünde çalıştırmak için React uygulamasını derleyip Electron ile açabilirsiniz:
+
+```bash
+cd frontend
+npm run build
+cd ../desktop
+npm install
+npm start
+```
+
 ## Servis Kurulumu
 
 ### Systemd

--- a/desktop/main.js
+++ b/desktop/main.js
@@ -1,0 +1,17 @@
+const { app, BrowserWindow } = require('electron');
+const path = require('path');
+
+function createWindow() {
+  const win = new BrowserWindow({
+    width: 1200,
+    height: 800,
+    webPreferences: {
+      nodeIntegration: false,
+      contextIsolation: true
+    }
+  });
+  const index = path.join(__dirname, '../frontend/build/index.html');
+  win.loadFile(index);
+}
+
+app.whenReady().then(createWindow);

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "telegram-desktop-app",
+  "version": "1.0.0",
+  "main": "main.js",
+  "scripts": {
+    "start": "electron ."
+  },
+  "devDependencies": {
+    "electron": "^25.2.0"
+  }
+}

--- a/frontend/src/assets/clear.svg
+++ b/frontend/src/assets/clear.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <path d="M5 5l14 14M19 5L5 19" stroke="#2b2b2b" stroke-width="2" stroke-linecap="round"/>
+</svg>

--- a/frontend/src/assets/copy.svg
+++ b/frontend/src/assets/copy.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <rect x="9" y="9" width="12" height="12" fill="#2b2b2b"/>
+  <rect x="3" y="3" width="12" height="12" fill="none" stroke="#2b2b2b" stroke-width="2"/>
+</svg>

--- a/frontend/src/assets/play.svg
+++ b/frontend/src/assets/play.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <polygon points="6,4 20,12 6,20" fill="#2b2b2b"/>
+</svg>

--- a/frontend/src/assets/save.svg
+++ b/frontend/src/assets/save.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <path d="M3 3h18v18H3z" fill="#2b2b2b"/>
+  <path d="M7 3h10v7H7zM7 14h10v7H7z" fill="#ffffff"/>
+</svg>

--- a/frontend/src/assets/stop.svg
+++ b/frontend/src/assets/stop.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <rect x="6" y="6" width="12" height="12" fill="#2b2b2b"/>
+</svg>

--- a/frontend/src/assets/test.svg
+++ b/frontend/src/assets/test.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <path d="M9 3h6v2h-1v6l3 7v3H7v-3l3-7V5H9z" fill="#2b2b2b"/>
+</svg>

--- a/frontend/src/components/LogViewer.js
+++ b/frontend/src/components/LogViewer.js
@@ -1,18 +1,22 @@
 import React, { useContext } from 'react';
 import { AppContext } from '../context/AppContext';
+import Panel from './Panel';
+import MinimalButton from './MinimalButton';
+import clearIcon from '../assets/clear.svg';
+import copyIcon from '../assets/copy.svg';
 
 export default function LogViewer(){
   const { log, clearLog } = useContext(AppContext);
   return (
-    <div style={{marginTop:16}}>
+    <Panel style={{marginTop:16}}>
       <div style={{fontSize:12,color:'#555',marginBottom:6}}>Loglar</div>
       <div style={{display:'flex',gap:8,marginBottom:8}}>
-        <button onClick={clearLog}>Logları Temizle</button>
-        <button onClick={()=>navigator.clipboard.writeText((log||[]).join("\n"))}>Kopyala</button>
+        <MinimalButton icon={clearIcon} onClick={clearLog}>Logları Temizle</MinimalButton>
+        <MinimalButton icon={copyIcon} onClick={()=>navigator.clipboard.writeText((log||[]).join("\n"))}>Kopyala</MinimalButton>
       </div>
       <pre style={{fontFamily:'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace',fontSize:12,background:'#fafafa',border:'1px solid #e7e7e7',borderRadius:10,padding:10,height:340,overflow:'auto',whiteSpace:'pre-wrap'}}>
         {(log && log.length)?log.join("\n"):"Log bekleniyor..."}
       </pre>
-    </div>
+    </Panel>
   );
 }

--- a/frontend/src/components/MinimalButton.js
+++ b/frontend/src/components/MinimalButton.js
@@ -1,0 +1,23 @@
+import React from 'react';
+
+export default function MinimalButton({ icon, children, style, ...props }) {
+  return (
+    <button
+      {...props}
+      style={{
+        display:'inline-flex',
+        alignItems:'center',
+        gap:6,
+        padding:'6px 12px',
+        border:'1px solid #ccc',
+        borderRadius:6,
+        background:'#f5f5f5',
+        cursor:'pointer',
+        ...style
+      }}
+    >
+      {icon && <img src={icon} alt="" style={{width:16,height:16}} />}
+      <span>{children}</span>
+    </button>
+  );
+}

--- a/frontend/src/components/Panel.js
+++ b/frontend/src/components/Panel.js
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default function Panel({ children, style }) {
+  return (
+    <div style={{background:'#fff',border:'1px solid #ddd',borderRadius:10,padding:16,...style}}>
+      {children}
+    </div>
+  );
+}

--- a/frontend/src/components/SettingsForm.js
+++ b/frontend/src/components/SettingsForm.js
@@ -1,6 +1,9 @@
 import React, { useContext, useEffect } from 'react';
 import { AppContext } from '../context/AppContext';
 import { fetchDialogs } from '../services/api';
+import Panel from './Panel';
+import MinimalButton from './MinimalButton';
+import saveIcon from '../assets/save.svg';
 
 export default function SettingsForm() {
   const { cfg, setField, save, dialogs, setDialogs } = useContext(AppContext);
@@ -17,7 +20,7 @@ export default function SettingsForm() {
   }, [setDialogs]);
 
   return (
-    <>
+    <Panel>
       <div style={{display:'grid',gap:12,gridTemplateColumns:'1.3fr 1fr 1fr 1fr'}}>
         <div><label style={{fontSize:12,color:'#555'}}>API ID</label><input value={cfg.api_id} onChange={e=>setField('api_id',e.target.value)} style={{width:'100%',padding:8,border:'1px solid #d0d0d0',borderRadius:10}}/></div>
         <div><label style={{fontSize:12,color:'#555'}}>API HASH</label><input value={cfg.api_hash} onChange={e=>setField('api_hash',e.target.value)} style={{width:'100%',padding:8,border:'1px solid #d0d0d0',borderRadius:10}}/></div>
@@ -65,8 +68,8 @@ export default function SettingsForm() {
           <input type="checkbox" checked={!!cfg.dry_run} onChange={e=>setField('dry_run',e.target.checked)}/>
           <span>Dry-run</span>
         </label>
-        <div style={{marginLeft:'auto'}}><button onClick={save}>Kaydet</button></div>
+        <div style={{marginLeft:'auto'}}><MinimalButton icon={saveIcon} onClick={save}>Kaydet</MinimalButton></div>
       </div>
-    </>
+    </Panel>
   );
 }

--- a/frontend/src/components/StatusPanel.js
+++ b/frontend/src/components/StatusPanel.js
@@ -1,20 +1,25 @@
 import React, { useContext } from 'react';
 import { AppContext } from '../context/AppContext';
+import Panel from './Panel';
+import MinimalButton from './MinimalButton';
+import playIcon from '../assets/play.svg';
+import stopIcon from '../assets/stop.svg';
+import testIcon from '../assets/test.svg';
 
 export default function StatusPanel(){
   const { running, progress, start, stop, cfg } = useContext(AppContext);
   const valid = cfg.api_id && cfg.api_hash && cfg.out;
   return (
-    <div style={{marginTop:16}}>
+    <Panel style={{marginTop:16}}>
       <div style={{display:'flex',justifyContent:'space-between',alignItems:'center',marginBottom:12}}>
         <span style={{padding:'6px 10px',borderRadius:999,fontSize:12,background:running?'#e9f7ee':'#e9ecef'}}>
           <span style={{display:'inline-block',width:8,height:8,borderRadius:999,background:running?'#2ecc71':'#6c757d',marginRight:6}}/>
           {running?"Çalışıyor":"Beklemede"}
         </span>
         <div style={{display:'flex',gap:8}}>
-          <button onClick={stop}>Durdur</button>
-          <button onClick={()=>start(false)} disabled={!valid}>Başlat</button>
-          <button onClick={()=>start(true)}>Dry-Run</button>
+          <MinimalButton icon={stopIcon} onClick={stop}>Durdur</MinimalButton>
+          <MinimalButton icon={playIcon} onClick={()=>start(false)} disabled={!valid}>Başlat</MinimalButton>
+          <MinimalButton icon={testIcon} onClick={()=>start(true)}>Dry-Run</MinimalButton>
         </div>
       </div>
       <div style={{display:'grid',gridTemplateColumns:'auto 1fr',columnGap:8,rowGap:6,fontSize:14}}>
@@ -23,6 +28,6 @@ export default function StatusPanel(){
         <div>İndirilen:</div><div>{progress?.downloaded??0}</div>
         <div>Atlanan:</div><div>{progress?.skipped??0}</div>
       </div>
-    </div>
+    </Panel>
   );
 }


### PR DESCRIPTION
## Summary
- add reusable Panel and MinimalButton components with SVG icons for a lightweight visual style
- integrate these components into settings, status, and log viewer panels
- introduce a basic Electron setup for running the app as a desktop client and document usage

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot find module '@testing-library/react')*
- `npm install` *(fails: 403 Forbidden for @testing-library/jest-dom)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab26409c0483338e9d2b0aa2ccea9c