### PR TITLE
Add icons and error tab

### DIFF
--- a/frontend/src/assets/contacts.svg
+++ b/frontend/src/assets/contacts.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <circle cx="12" cy="8" r="4" fill="none" stroke="#2b2b2b" stroke-width="2"/>
+  <path d="M4 21v-2a8 8 0 0116 0v2" fill="none" stroke="#2b2b2b" stroke-width="2"/>
+</svg>

--- a/frontend/src/assets/error.svg
+++ b/frontend/src/assets/error.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <path d="M12 3l9 16H3z" fill="none" stroke="#2b2b2b" stroke-width="2"/>
+  <path d="M12 10v4M12 17h.01" stroke="#2b2b2b" stroke-width="2" stroke-linecap="round"/>
+</svg>

--- a/frontend/src/assets/faq.svg
+++ b/frontend/src/assets/faq.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <circle cx="12" cy="12" r="10" fill="none" stroke="#2b2b2b" stroke-width="2"/>
+  <path d="M12 16v2M9.5 9a2.5 2.5 0 115 0c0 1.5-2.5 2-2.5 4" fill="none" stroke="#2b2b2b" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/frontend/src/assets/log.svg
+++ b/frontend/src/assets/log.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <path d="M4 6h16M4 12h16M4 18h16" stroke="#2b2b2b" stroke-width="2" stroke-linecap="round"/>
+</svg>

--- a/frontend/src/assets/panel.svg
+++ b/frontend/src/assets/panel.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <path d="M3 10l9-7 9 7v11H3z" fill="none" stroke="#2b2b2b" stroke-width="2"/>
+  <path d="M9 21V12h6v9" fill="none" stroke="#2b2b2b" stroke-width="2"/>
+</svg>

--- a/frontend/src/assets/settings.svg
+++ b/frontend/src/assets/settings.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <circle cx="12" cy="12" r="3" fill="none" stroke="#2b2b2b" stroke-width="2"/>
+  <path d="M4 12h2M18 12h2M12 4v2M12 18v2M5.64 5.64l1.41 1.41M16.95 16.95l1.41 1.41M5.64 18.36l1.41-1.41M16.95 7.05l1.41-1.41" stroke="#2b2b2b" stroke-width="2" stroke-linecap="round"/>
+</svg>

--- a/frontend/src/assets/status.svg
+++ b/frontend/src/assets/status.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <path d="M5 3v18h14" stroke="#2b2b2b" stroke-width="2" fill="none"/>
+  <rect x="8" y="10" width="3" height="7" fill="#2b2b2b"/>
+  <rect x="13" y="6" width="3" height="11" fill="#2b2b2b"/>
+</svg>

--- a/frontend/src/components/ControlPanel.js
+++ b/frontend/src/components/ControlPanel.js
@@ -2,21 +2,24 @@ import React, { useContext, useEffect, useState } from 'react';
 import SettingsForm from './SettingsForm';
 import StatusPanel from './StatusPanel';
 import LogViewer from './LogViewer';
-codex/add-kisiler-sekmesi
+import ErrorViewer from './ErrorViewer';
 import ContactsPanel from './ContactsPanel';
-
 import FaqSection from './FaqSection';
-main
+import MinimalButton from './MinimalButton';
+import panelIcon from '../assets/panel.svg';
+import faqIcon from '../assets/faq.svg';
+import settingsIcon from '../assets/settings.svg';
+import statusIcon from '../assets/status.svg';
+import logIcon from '../assets/log.svg';
+import errorIcon from '../assets/error.svg';
+import contactsIcon from '../assets/contacts.svg';
 import { AppContext } from '../context/AppContext';
 import { fetchDialogs } from '../services/api';
 
 export default function ControlPanel(){
-  const { error, setDialogs } = useContext(AppContext);
-codex/add-kisiler-sekmesi
-  const [tab, setTab] = useState('settings');
-
-  const [tab, setTab] = useState('panel');
-main
+  const { setDialogs } = useContext(AppContext);
+  const [mainTab, setMainTab] = useState('panel');
+  const [subTab, setSubTab] = useState('settings');
 
   useEffect(() => {
     fetchDialogs().then(r => {
@@ -25,41 +28,32 @@ main
       }
     });
   }, [setDialogs]);
+
   return (
     <div style={{maxWidth:1100,margin:'24px auto',padding:'0 16px'}}>
       <h1 style={{fontSize:22,margin:0,marginBottom:12}}>Telegram Arşivleyici — Kontrol Paneli</h1>
       <div style={{display:'flex',gap:8,marginBottom:12}}>
-        <button onClick={()=>setTab('panel')}>Kontrol Paneli</button>
-        <button onClick={()=>setTab('faq')}>SSS</button>
+        <MinimalButton icon={panelIcon} onClick={()=>setMainTab('panel')}>Kontrol Paneli</MinimalButton>
+        <MinimalButton icon={faqIcon} onClick={()=>setMainTab('faq')}>SSS</MinimalButton>
       </div>
-      {error && (
-        <div style={{background:'#f8d7da',border:'1px solid #f5c2c7',borderRadius:10,padding:10,marginBottom:12}}>
-          {error}
-        </div>
-      )}
-codex/add-kisiler-sekmesi
-      <div style={{display:'flex',gap:8,marginBottom:12}}>
-        <button onClick={()=>setTab('settings')}>Ayarlar</button>
-        <button onClick={()=>setTab('status')}>Durum</button>
-        <button onClick={()=>setTab('log')}>Loglar</button>
-        <button onClick={()=>setTab('contacts')}>Kişiler</button>
-      </div>
-      {tab === 'settings' && <SettingsForm />}
-      {tab === 'status' && <StatusPanel />}
-      {tab === 'log' && <LogViewer />}
-      {tab === 'contacts' && <ContactsPanel />}
-
-      {tab === 'panel' ? (
+      {mainTab === 'panel' ? (
         <>
-          <SettingsForm />
-          <StatusPanel />
-          <LogViewer />
+          <div style={{display:'flex',gap:8,marginBottom:12,flexWrap:'wrap'}}>
+            <MinimalButton icon={settingsIcon} onClick={()=>setSubTab('settings')}>Ayarlar</MinimalButton>
+            <MinimalButton icon={statusIcon} onClick={()=>setSubTab('status')}>Durum</MinimalButton>
+            <MinimalButton icon={logIcon} onClick={()=>setSubTab('log')}>Loglar</MinimalButton>
+            <MinimalButton icon={errorIcon} onClick={()=>setSubTab('errors')}>Hatalar</MinimalButton>
+            <MinimalButton icon={contactsIcon} onClick={()=>setSubTab('contacts')}>Kişiler</MinimalButton>
+          </div>
+          {subTab === 'settings' && <SettingsForm />}
+          {subTab === 'status' && <StatusPanel />}
+          {subTab === 'log' && <LogViewer />}
+          {subTab === 'errors' && <ErrorViewer />}
+          {subTab === 'contacts' && <ContactsPanel />}
         </>
       ) : (
         <FaqSection />
       )}
-main
     </div>
   );
 }
-

--- a/frontend/src/components/ErrorViewer.js
+++ b/frontend/src/components/ErrorViewer.js
@@ -1,0 +1,22 @@
+import React, { useContext } from 'react';
+import { AppContext } from '../context/AppContext';
+import MinimalButton from './MinimalButton';
+import clearIcon from '../assets/clear.svg';
+
+export default function ErrorViewer(){
+  const { errors, clearErrors } = useContext(AppContext);
+  return (
+    <div style={{marginTop:16}}>
+      <div style={{display:'flex',justifyContent:'space-between',marginBottom:8}}>
+        <div style={{fontSize:12,color:'#555'}}>Hatalar</div>
+        <MinimalButton icon={clearIcon} onClick={clearErrors}>Temizle</MinimalButton>
+      </div>
+      <div style={{maxHeight:300,overflowY:'auto',border:'1px solid #d0d0d0',borderRadius:10,padding:8}}>
+        {errors.map((e,i)=>(
+          <div key={i} style={{padding:'4px 0',borderBottom:'1px solid #eee',color:'#c00',fontSize:12}}>{e}</div>
+        ))}
+        {errors.length===0 && <div style={{fontSize:12,color:'#999'}}>Hata yok</div>}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/context/AppContext.js
+++ b/frontend/src/context/AppContext.js
@@ -28,33 +28,40 @@ export function AppProvider({ children }) {
   const [log, setLog] = useState([]);
   const [progress, setProgress] = useState(defaultProgress);
   const [error, setError] = useState('');
+  const [errors, setErrors] = useState([]);
   const [dialogs, setDialogs] = useState([]);
 
   const setField = (k, v) => setCfg(c => ({ ...c, [k]: v }));
   const clearLog = () => setLog([]);
+  const clearErrors = () => setErrors([]);
+
+  const recordError = (msg) => {
+    setError(msg);
+    if (msg) setErrors(prev => [...prev, msg]);
+  };
 
   async function save() {
-    setError('');
+    recordError('');
     const r = await saveConfig(cfg);
-    if (!r.ok) setError(r.error?.message || 'Kaydetme hatası');
+    if (!r.ok) recordError(r.error?.message || 'Kaydetme hatası');
   }
 
   async function start(dry) {
-    setError('');
+    recordError('');
     const r = await startRun(cfg, dry, cfg.chats);
-    if (!r.ok) setError(r.error?.message || 'Başlatma hatası');
+    if (!r.ok) recordError(r.error?.message || 'Başlatma hatası');
   }
 
   async function stop() {
-    setError('');
+    recordError('');
     const r = await stopRun();
-    if (!r.ok) setError(r.error?.message || 'Durdurma hatası');
+    if (!r.ok) recordError(r.error?.message || 'Durdurma hatası');
   }
 
   useEffect(() => {
     fetchConfig().then(r => {
       if (r.ok && r.data) setCfg(o => ({ ...o, ...r.data }));
-      else if (r.error) setError(r.error.message || 'Config alınamadı');
+      else if (r.error) recordError(r.error.message || 'Config alınamadı');
     });
   }, []);
 
@@ -70,7 +77,7 @@ export function AppProvider({ children }) {
             setProgress(s.progress || defaultProgress);
             if (Array.isArray(s.logTail)) setLog(p => [...p, ...s.logTail].slice(-400));
           } else if (r.error) {
-            setError(r.error.message || 'Durum alınamadı');
+            recordError(r.error.message || 'Durum alınamadı');
           }
         })
         .finally(() => {
@@ -95,6 +102,8 @@ export function AppProvider({ children }) {
         log,
         clearLog,
         error,
+        errors,
+        clearErrors,
         dialogs,
         setDialogs,
       }}


### PR DESCRIPTION
## Summary
- Add minimal black-and-white SVG icons and use them across ControlPanel buttons
- Track error history in context and display it in new ErrorViewer tab

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot find module '@testing-library/react')*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab2859b388833388098085fdddde12