### PR TITLE
Add media counts and photos for group listing

### DIFF
--- a/backend/tests/test_dialogs_api.py
+++ b/backend/tests/test_dialogs_api.py
@@ -2,6 +2,7 @@ import asyncio
 import sys
 from pathlib import Path
 from types import SimpleNamespace
+import base64
 
 sys.path.append(str(Path(__file__).resolve().parents[2]))
 from backend import main
@@ -18,27 +19,37 @@ class DialogClient:
         pass
 
     async def iter_dialogs(self):
-        yield SimpleNamespace(id=1, name="chat1")
-        yield SimpleNamespace(id=2, name="chat2")
+        yield SimpleNamespace(id=1, name="chat1", is_group=True)
+
+    async def get_messages(self, *args, **kwargs):
+        class R:
+            def __init__(self, total):
+                self.total = total
+
+        flt = kwargs.get("filter")
+        if isinstance(flt, main.tl_types.InputMessagesFilterPhotos):
+            return R(1)
+        if isinstance(flt, main.tl_types.InputMessagesFilterVideo):
+            return R(2)
+        if isinstance(flt, main.tl_types.InputMessagesFilterDocument):
+            return R(3)
+        return R(0)
+
+    async def download_profile_photo(self, *args, **kwargs):
+        return b"img"
 
 
 def test_dialogs_endpoint(monkeypatch):
     monkeypatch.setattr(main, "TelegramClient", lambda *a, **k: DialogClient())
     monkeypatch.setattr(main, "load_cfg", lambda: main.Config(api_id="1", api_hash="h"))
     data = asyncio.run(main.list_dialogs())
+    expected_photo = "data:image/jpeg;base64," + base64.b64encode(b"img").decode()
     assert data == [
         {
             "id": 1,
             "name": "chat1",
             "username": None,
-            "photo": None,
-            "counts": {"photos": 0, "videos": 0, "documents": 0},
-        },
-        {
-            "id": 2,
-            "name": "chat2",
-            "username": None,
-            "photo": None,
-            "counts": {"photos": 0, "videos": 0, "documents": 0},
-        },
+            "photo": expected_photo,
+            "counts": {"photos": 1, "videos": 2, "documents": 3},
+        }
     ]


### PR DESCRIPTION
## Summary
- Populate `/api/dialogs` with media counts for joined groups/channels
- Include optional profile photos and skip non-group dialogs
- Update tests for new dialog response structure

## Testing
- `python -m pytest`
- `npm test -- --watchAll=false` *(fails: Cannot find module '@testing-library/react'; `npm install` forbidden 403)*

------
https://chatgpt.com/codex/tasks/task_e_68ab2b5f71e483338e858214d8d043d2