### PR TITLE
Log failed downloads and report retries

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -273,10 +273,11 @@ async def download_worker(
                         try:
                             await download_file(client, m, tdir)
                             STATE["progress"]["downloaded"] += 1
-                            break
-                        except Exception:
+                            return True
+                        except Exception as exc:
                             if attempt == 2:
-                                break
+                                log(f"[error] download failed for {dname}: {exc}")
+                                return False
                             await asyncio.sleep(cfg.throttle)
 
             tasks.append(asyncio.create_task(runner()))

--- a/backend/tests/test_worker_download_failures.py
+++ b/backend/tests/test_worker_download_failures.py
@@ -1,0 +1,48 @@
+import asyncio
+import datetime as dt
+from types import SimpleNamespace
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+from backend import main
+
+
+class FailingClient:
+    async def connect(self):
+        pass
+
+    async def is_user_authorized(self):
+        return True
+
+    async def disconnect(self):
+        pass
+
+    async def iter_dialogs(self):
+        yield SimpleNamespace(name="chat", id=1)
+
+    async def iter_messages(self, dialog, reverse=True, filter=None):
+        yield SimpleNamespace(id=1, date=dt.datetime.now(), photo=True)
+
+
+def test_worker_logs_download_failures(monkeypatch, tmp_path):
+    monkeypatch.setattr(main, "TelegramClient", lambda *a, **k: FailingClient())
+
+    calls = 0
+
+    async def failing_download(client, msg, target_dir):
+        nonlocal calls
+        calls += 1
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(main, "download_file", failing_download)
+    main.STATE["log"] = []
+
+    cfg = main.Config(api_id="1", api_hash="h", types=["photos"], out=str(tmp_path))
+    asyncio.run(main.download_worker(cfg))
+
+    assert calls == 3
+    assert any("[error] download failed for chat: boom" in entry for entry in main.STATE["log"])


### PR DESCRIPTION
## Summary
- Log download failures with exception details after final retry
- Return success flag from worker runner to allow tracking
- Test logging when a download fails repeatedly

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b02e724b348333b1c092699fbabb09