### PR TITLE
Handle bad config JSON errors

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -87,8 +87,9 @@ def load_cfg() -> Config:
     if CFG_FILE.exists():
         try:
             data = json.loads(CFG_FILE.read_text("utf-8"))
-        except Exception:
-            data = {}
+        except Exception as exc:
+            log(f"[error] failed to load config: {exc}")
+            raise HTTPException(status_code=500, detail="Failed to load config") from exc
     else:
         data = {}
     cfg = Config(**data)

--- a/backend/tests/test_load_cfg.py
+++ b/backend/tests/test_load_cfg.py
@@ -1,0 +1,17 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+import main as main
+
+
+def test_load_cfg_malformed_json(tmp_path, capsys, monkeypatch):
+    bad_cfg = tmp_path / "config.json"
+    bad_cfg.write_text("{ invalid json }", encoding="utf-8")
+    monkeypatch.setattr(main, "CFG_FILE", bad_cfg)
+    with pytest.raises(main.HTTPException):
+        main.load_cfg()
+    out = capsys.readouterr().out
+    assert "failed to load config" in out


### PR DESCRIPTION
## Summary
- Log and raise clear error when `config.json` cannot be parsed
- Test that malformed config files trigger error logging and HTTPException

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b02e6e263483339f4a9fb03f4f12c6