### PR TITLE
Propagate API errors to UI with tests

### DIFF
--- a/frontend/src/__tests__/ControlPanel.test.js
+++ b/frontend/src/__tests__/ControlPanel.test.js
@@ -10,13 +10,15 @@ jest.mock('../services/api', () => ({
   fetchDialogs: jest.fn(),
 }));
 
-test('handles fetchDialogs error', async () => {
+test('alerts on fetchDialogs error', async () => {
   fetchDialogs.mockRejectedValue(new Error('fail'));
+  const alert = jest.spyOn(window, 'alert').mockImplementation(() => {});
   const value = { setDialogs: () => {} };
   render(
     <AppContext.Provider value={value}>
       <ControlPanel />
     </AppContext.Provider>
   );
-  await waitFor(() => expect(fetchDialogs).toHaveBeenCalled());
+  await waitFor(() => expect(alert).toHaveBeenCalledWith('fail'));
+  alert.mockRestore();
 });

--- a/frontend/src/__tests__/SettingsForm.test.js
+++ b/frontend/src/__tests__/SettingsForm.test.js
@@ -20,8 +20,9 @@ test('renders settings inputs', () => {
   expect(screen.getByText(/Kaydet/)).toBeInTheDocument();
 });
 
-test('handles save errors', async () => {
+test('alerts on save errors', async () => {
   const save = jest.fn().mockRejectedValue(new Error('fail'));
+  const alert = jest.spyOn(window, 'alert').mockImplementation(() => {});
   const value = {
     cfg: { session:'', out:'', types:[], dry_run:false },
     setField: () => {},
@@ -33,5 +34,6 @@ test('handles save errors', async () => {
     </AppContext.Provider>
   );
   fireEvent.click(screen.getByText(/Kaydet/));
-  await waitFor(() => expect(save).toHaveBeenCalled());
+  await waitFor(() => expect(alert).toHaveBeenCalledWith('fail'));
+  alert.mockRestore();
 });

--- a/frontend/src/__tests__/api.test.js
+++ b/frontend/src/__tests__/api.test.js
@@ -1,0 +1,19 @@
+import { fetchConfig } from '../services/api';
+
+const originalFetch = global.fetch;
+
+afterEach(() => {
+  global.fetch = originalFetch;
+});
+
+test('fetchConfig throws detailed error on failure', async () => {
+  global.fetch = jest.fn().mockResolvedValue({
+    ok: false,
+    status: 500,
+    text: () => Promise.resolve('{"detail":"boom"}')
+  });
+  await expect(fetchConfig()).rejects.toMatchObject({
+    status: 500,
+    body: { detail: 'boom' }
+  });
+});

--- a/frontend/src/components/ControlPanel.js
+++ b/frontend/src/components/ControlPanel.js
@@ -30,7 +30,7 @@ export default function ControlPanel(){
           setDialogs(d);
         }
       })
-      .catch(err => console.error(err));
+      .catch(err => window.alert(err.message || 'Diyaloglar alınamadı'));
   }, [setDialogs]);
 
   return (

--- a/frontend/src/components/SettingsForm.js
+++ b/frontend/src/components/SettingsForm.js
@@ -28,7 +28,7 @@ export default function SettingsForm() {
           <input type="checkbox" checked={!!cfg.dry_run} onChange={e=>setField('dry_run',e.target.checked)}/>
           <span>Dry-run</span>
         </label>
-        <div style={{marginLeft:'auto'}}><MinimalButton icon={saveIcon} onClick={async ()=>{ try { await save(); } catch(e){} }}>Kaydet</MinimalButton></div>
+        <div style={{marginLeft:'auto'}}><MinimalButton icon={saveIcon} onClick={async ()=>{ try { await save(); } catch(e){ window.alert(e.message || 'Kaydetme hatası'); } }}>Kaydet</MinimalButton></div>
       </div>
     </Panel>
   );


### PR DESCRIPTION
## Summary
- Throw detailed errors from API service when responses are not OK
- Alert users on failure in SettingsForm and ControlPanel
- Add tests for API error propagation and component handling

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot find module '@testing-library/react')*


------
https://chatgpt.com/codex/tasks/task_e_68b02e72e4c08333a1fe0f003a433216