### PR TITLE
Add repository maintenance helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,20 @@ cp frontend/.env.example frontend/.env
 # edit frontend/.env and set REACT_APP_API_BASE as needed
 ```
 
+## Code Maintenance
+
+Tüm kod tabanını hızlıca kontrol etmek veya biçimlendirmek için `maintainer.py` aracını kullanın.
+
+```bash
+# sorunları bulmak için
+python maintainer.py check
+
+# otomatik düzeltme yapmak için
+python maintainer.py fix
+```
+
+`check` komutu hem Python backend'i hem de React frontend'i için testleri ve statik analizleri çalıştırır. `fix` komutu ise uygun araçlar mevcutsa otomatik biçimlendirme ve lint düzeltmeleri uygular.
+
 ## Masaüstü Uygulaması
 
 Frontend'i masaüstünde çalıştırmak için React uygulamasını derleyip Electron ile açabilirsiniz:

--- a/maintainer.py
+++ b/maintainer.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Repository maintenance helper.
+
+Usage:
+    python maintainer.py check  # run tests and static checks
+    python maintainer.py fix    # apply auto-formatters
+"""
+from pathlib import Path
+import subprocess
+import sys
+
+ROOT = Path(__file__).resolve().parent
+
+
+def run(cmd, cwd=None):
+    print(f"\n$ {' '.join(cmd)}")
+    try:
+        subprocess.run(cmd, cwd=cwd, check=True)
+    except FileNotFoundError:
+        print(f"Komut bulunamadı: {cmd[0]}")
+    except subprocess.CalledProcessError as e:
+        print(f"Komut hata kodu {e.returncode} ile bitti")
+
+
+def check():
+    # backend tests and lint
+    run([sys.executable, "-m", "pytest"], cwd=ROOT / "backend")
+    run(["flake8", "backend", "tests"], cwd=ROOT)
+
+    # frontend tests and lint
+    run(["npm", "test", "--", "--watchAll=false"], cwd=ROOT / "frontend")
+    run(["npx", "eslint", "src"], cwd=ROOT / "frontend")
+
+
+def fix():
+    # auto-format python
+    run(["black", "backend", "tests"], cwd=ROOT)
+
+    # auto-fix frontend
+    run(["npx", "eslint", "src", "--fix"], cwd=ROOT / "frontend")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2 or sys.argv[1] not in {"check", "fix"}:
+        print(__doc__)
+        sys.exit(1)
+
+    if sys.argv[1] == "check":
+        check()
+    else:
+        fix()


### PR DESCRIPTION
## Summary
- add maintainer.py to run tests, lint, and auto-format
- document maintainer.py usage in README

## Testing
- `python maintainer.py check` *(fails: flake8 missing; frontend tests missing @testing-library/react; eslint config missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b0398a16dc8333aff4a73b12c3837d