### PR TITLE
refactor: remove testing-library dependency

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,10 +11,6 @@
     "start": "node node_modules/react-scripts/bin/react-scripts.js start",
     "test": "node node_modules/react-scripts/bin/react-scripts.js test"
   },
-  "devDependencies": {
-    "@testing-library/jest-dom": "^6.1.5",
-    "@testing-library/react": "^14.1.2"
-  },
   "browserslist": {
     "production": [
       ">0.2%",

--- a/frontend/src/__tests__/ContactsPanel.test.js
+++ b/frontend/src/__tests__/ContactsPanel.test.js
@@ -1,13 +1,10 @@
 import React from 'react';
-import { render, screen, waitFor } from '@testing-library/react';
-import '@testing-library/jest-dom';
-
-jest.mock('../services/api', () => ({
-  fetchContacts: jest.fn(() => Promise.resolve({ ok: true, data: [{ id: 1, full_name: 'Alice' }] })),
-}));
-
-import { fetchContacts } from '../services/api';
+import { render, screen, waitFor } from '../test-utils';
+import * as api from '../services/api';
 import ContactsPanel from '../components/ContactsPanel';
+
+api.fetchContacts = jest.fn(() => Promise.resolve({ ok: true, data: [{ id: 1, full_name: 'Alice' }] }));
+const { fetchContacts } = api;
 
 test('renders contact list', async () => {
   render(<ContactsPanel />);

--- a/frontend/src/__tests__/ControlPanel.test.js
+++ b/frontend/src/__tests__/ControlPanel.test.js
@@ -1,6 +1,5 @@
 import React from 'react';
-import { render, waitFor } from '@testing-library/react';
-import '@testing-library/jest-dom';
+import { render, waitFor } from '../test-utils';
 
 import ControlPanel from '../components/ControlPanel';
 import { AppContext } from '../context/AppContext';
@@ -13,7 +12,7 @@ jest.mock('../services/api', () => ({
 test('alerts on fetchDialogs error', async () => {
   fetchDialogs.mockRejectedValue(new Error('fail'));
   const alert = jest.spyOn(window, 'alert').mockImplementation(() => {});
-  const value = { setDialogs: () => {} };
+  const value = { setDialogs: () => {}, cfg: { api_id:'', api_hash:'' } };
   render(
     <AppContext.Provider value={value}>
       <ControlPanel />

--- a/frontend/src/__tests__/FaqSection.test.js
+++ b/frontend/src/__tests__/FaqSection.test.js
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen } from '../test-utils';
 import FaqSection from '../components/FaqSection';
 
 test('shows FAQ heading and contact email', () => {

--- a/frontend/src/__tests__/GroupsPanel.test.js
+++ b/frontend/src/__tests__/GroupsPanel.test.js
@@ -1,6 +1,5 @@
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
-import '@testing-library/jest-dom';
+import { render, screen, fireEvent } from '../test-utils';
 
 import GroupsPanel from '../components/GroupsPanel';
 import { AppContext } from '../context/AppContext';

--- a/frontend/src/__tests__/LogViewer.test.js
+++ b/frontend/src/__tests__/LogViewer.test.js
@@ -1,6 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
-import '@testing-library/jest-dom';
+import { render, screen } from '../test-utils';
 import LogViewer from '../components/LogViewer';
 import { AppContext } from '../context/AppContext';
 

--- a/frontend/src/__tests__/ProfilePanel.test.js
+++ b/frontend/src/__tests__/ProfilePanel.test.js
@@ -1,6 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
-import '@testing-library/jest-dom';
+import { render, screen } from '../test-utils';
 
 import ProfilePanel from '../components/ProfilePanel';
 import { AppContext } from '../context/AppContext';

--- a/frontend/src/__tests__/SettingsForm.test.js
+++ b/frontend/src/__tests__/SettingsForm.test.js
@@ -1,6 +1,5 @@
 import React from 'react';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import '@testing-library/jest-dom';
+import { render, screen, fireEvent, waitFor } from '../test-utils';
 
 import SettingsForm from '../components/SettingsForm';
 import { AppContext } from '../context/AppContext';

--- a/frontend/src/__tests__/StatusPanel.test.js
+++ b/frontend/src/__tests__/StatusPanel.test.js
@@ -1,6 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
-import '@testing-library/jest-dom';
+import { render, screen } from '../test-utils';
 import StatusPanel from '../components/StatusPanel';
 import { AppContext } from '../context/AppContext';
 

--- a/frontend/src/setupTests.js
+++ b/frontend/src/setupTests.js
@@ -1,0 +1,23 @@
+global.IS_REACT_ACT_ENVIRONMENT = true;
+
+expect.extend({
+  toBeInTheDocument(received) {
+    const pass = document.body.contains(received);
+    return {
+      pass,
+      message: () => `expected element ${pass ? 'not ' : ''}to be in the document`,
+    };
+  },
+  toHaveAttribute(received, name, value) {
+    const pass = received.hasAttribute(name) &&
+      (value === undefined || received.getAttribute(name) === String(value));
+    return {
+      pass,
+      message: () => `expected element ${pass ? 'not ' : ''}to have attribute ${name}${value !== undefined ? `="${value}"` : ''}`,
+    };
+  }
+});
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});

--- a/frontend/src/test-utils.js
+++ b/frontend/src/test-utils.js
@@ -1,0 +1,108 @@
+import { createRoot } from 'react-dom/client';
+import { act } from 'react-dom/test-utils';
+
+function render(ui) {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => {
+    root.render(ui);
+  });
+  return { container, unmount: () => root.unmount() };
+}
+
+function matchText(node, matcher) {
+  const text = node.textContent || '';
+  if (typeof matcher === 'string') {
+    return text.includes(matcher);
+  }
+  if (matcher instanceof RegExp) {
+    return matcher.test(text);
+  }
+  return false;
+}
+
+function getByText(matcher) {
+  const elements = Array.from(document.body.querySelectorAll('*'));
+  const el = elements.find(e => matchText(e, matcher));
+  if (!el) {
+    throw new Error(`Unable to find element with text: ${matcher}`);
+  }
+  return el;
+}
+
+function getByLabelText(matcher) {
+  const labels = Array.from(document.body.querySelectorAll('label'));
+  const label = labels.find(l => matchText(l, matcher));
+  if (!label) {
+    throw new Error(`Unable to find label: ${matcher}`);
+  }
+  if (label.htmlFor) {
+    const input = document.getElementById(label.htmlFor);
+    if (input) return input;
+  }
+  if (label.control) {
+    return label.control;
+  }
+  const nested = label.querySelector('input,textarea,select');
+  if (nested) return nested;
+  const parent = label.parentElement;
+  if (parent) {
+    const input = parent.querySelector('input,textarea,select');
+    if (input) return input;
+  }
+  throw new Error(`Label ${matcher} has no associated control`);
+}
+
+function getByRole(role, { name } = {}) {
+  const elements = Array.from(document.body.querySelectorAll('*'));
+  const el = elements.find(e => {
+    if (role === 'link' && e.tagName === 'A') {
+      return name ? matchText(e, name) : true;
+    }
+    return false;
+  });
+  if (!el) {
+    throw new Error(`Unable to find role ${role} with name ${name}`);
+  }
+  return el;
+}
+
+async function waitFor(callback, { timeout = 1000, interval = 50 } = {}) {
+  const start = Date.now();
+  while (true) {
+    try {
+      callback();
+      return;
+    } catch (err) {
+      if (Date.now() - start > timeout) {
+        throw err;
+      }
+      await new Promise(res => setTimeout(res, interval));
+    }
+  }
+}
+
+async function findByText(matcher) {
+  await waitFor(() => getByText(matcher));
+  return getByText(matcher);
+}
+
+const screen = { getByText, getByLabelText, getByRole, findByText };
+
+const fireEvent = {
+  click(node) {
+    act(() => {
+      node.click();
+    });
+  },
+  change(node, { target }) {
+    act(() => {
+      node.value = target.value;
+      const event = new Event('input', { bubbles: true, cancelable: true });
+      node.dispatchEvent(event);
+    });
+  }
+};
+
+export { render, screen, fireEvent, waitFor };


### PR DESCRIPTION
## Summary
- remove @testing-library/react usage and dev dependency
- implement minimal custom test utilities and matchers

## Testing
- `CI=true npm test -- --watchAll=false` *(fails: 2 failed, 7 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68b03b375b0c8333b6a4a61458043eae