### PR TITLE
Handle contact fetch failures gracefully

### DIFF
--- a/frontend/src/components/ContactsPanel.js
+++ b/frontend/src/components/ContactsPanel.js
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
-import { fetchContacts } from '../services/api';
+// Use CommonJS require so tests can easily monkeypatch exports
+const api = require('../services/api');
 
 export default function ContactsPanel(){
   const [items, setItems] = useState([]);
@@ -7,11 +8,16 @@ export default function ContactsPanel(){
 
   useEffect(() => {
     let alive = true;
-    fetchContacts().then(r => {
-      if (!alive) return;
-      if (r.ok && Array.isArray(r.data)) setItems(r.data);
-      else if (r.error) setError(r.error.message || 'Kişiler alınamadı');
-    });
+    (async () => {
+      try {
+        const r = await api.fetchContacts();
+        if (!alive) return;
+        if (r && r.ok && Array.isArray(r.data)) setItems(r.data);
+        else if (r && r.error) setError(r.error.message || 'Kişiler alınamadı');
+      } catch (e) {
+        if (alive) setError(e.message || 'Kişiler alınamadı');
+      }
+    })();
     return () => { alive = false; };
   }, []);
 

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -55,7 +55,12 @@ export async function fetchDialogs(){
 }
 
 export async function fetchContacts(){
-  return getJSON('/api/contacts');
+  try {
+    const data = await getJSON('/api/contacts');
+    return { ok: true, data };
+  } catch (error) {
+    return { ok: false, error };
+  }
 }
 
 export { API_BASE };


### PR DESCRIPTION
## Summary
- Return structured result from `fetchContacts` to surface network errors instead of crashing
- Load contacts panel using an async effect and show an error message when contact fetch fails

## Testing
- `npm test -- --watchAll=false` *(fails: alerts on save errors; renders contact list)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b03fb67f8c8333a6b440c41d6c866c