### PR TITLE
docs: add troubleshooting guidance for Windows startup error

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,3 +90,13 @@ Konfigürasyon dosyalarını test etmek için:
 ```bash
 bash deploy/tests/test_service_scripts.sh
 ```
+
+## Troubleshooting
+
+If you receive a `0xc0000142` error when launching the program, it indicates a Windows startup issue that occurs *before* the application code runs. To resolve it:
+
+- Run **System File Check** (`sfc /scannow`) to repair corrupted system files.
+- Reinstall the latest **Microsoft Visual C++ Redistributable** packages.
+- Add the application folder to your antivirus software's **exclusion list**.
+
+Because this error originates from Windows itself, verify that your operating system is healthy and fully updated before trying to run the application again.


### PR DESCRIPTION
## Summary
- add Troubleshooting section describing 0xc0000142 startup error
- suggest system file check, VC++ runtime reinstall, and antivirus exclusion
- note the error occurs before application code runs so Windows must be verified

## Testing
- `python maintainer.py check` *(fails: SettingsForm.test.js & ContactsPanel.test.js; flake8 and ESLint missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b0461df7fc8333ab9617104ea3de41