### PR TITLE
Add cmd.exe presence check to batch scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,3 +90,9 @@ Konfigürasyon dosyalarını test etmek için:
 ```bash
 bash deploy/tests/test_service_scripts.sh
 ```
+
+## Troubleshooting
+
+### `cmd.exe bulunamadi` mesaji
+
+Betik dosyalari Windows icin tasarlanmistir ve `cmd.exe` gerektirir. Bu hata gorunuyorsa komutlari bir Windows komut isteminde calistirdiginizdan ve `cmd.exe`'nin PATH icinde oldugundan emin olun.

--- a/doctor.bat
+++ b/doctor.bat
@@ -1,4 +1,5 @@
 @echo off
+where cmd >nul 2>nul || ( echo cmd.exe bulunamadi. Lutfen README.md'deki sorun giderme bolumune bakin. & pause & exit /b 1 )
 title Administrator: doctor
 cd /d "%~dp0backend"
 start "doctor" cmd /k ".venv\Scripts\python doctor.py"

--- a/login-qr.bat
+++ b/login-qr.bat
@@ -1,4 +1,5 @@
 @echo off
+where cmd >nul 2>nul || ( echo cmd.exe bulunamadi. Lutfen README.md'deki sorun giderme bolumune bakin. & pause & exit /b 1 )
 setlocal
 cd /d "%~dp0"
 if exist .venv\Scripts\python.exe (

--- a/login_once.bat
+++ b/login_once.bat
@@ -1,4 +1,5 @@
 @echo off
+where cmd >nul 2>nul || ( echo cmd.exe bulunamadi. Lutfen README.md'deki sorun giderme bolumune bakin. & pause & exit /b 1 )
 title Administrator: login_once
 setlocal
 cd /d "%~dp0"

--- a/menu.bat
+++ b/menu.bat
@@ -1,4 +1,5 @@
 @echo off
+where cmd >nul 2>nul || ( echo cmd.exe bulunamadi. Lutfen README.md'deki sorun giderme bolumune bakin. & pause & exit /b 1 )
 title Administrator: menu
 setlocal
 cd /d "%~dp0"

--- a/run-all.bat
+++ b/run-all.bat
@@ -1,6 +1,7 @@
 @echo off
 setlocal
 cd /d %~dp0
+where cmd >nul 2>nul || ( echo cmd.exe bulunamadi. Lutfen README.md'deki sorun giderme bolumune bakin. & pause & exit /b 1 )
 if not exist logs mkdir logs
 where python >nul 2>nul || ( echo Python bulunamadi. Lutfen Python 3.10+ kurun. & pause & exit /b 1 )
 if not exist .venv ( python -m venv .venv )

--- a/start_all.bat
+++ b/start_all.bat
@@ -1,4 +1,5 @@
 @echo off
+where cmd >nul 2>nul || ( echo cmd.exe bulunamadi. Lutfen README.md'deki sorun giderme bolumune bakin. & pause & exit /b 1 )
 title Administrator: start_all
 setlocal ENABLEDELAYEDEXPANSION
 cd /d "%~dp0"

--- a/stop_all.bat
+++ b/stop_all.bat
@@ -1,4 +1,5 @@
 @echo off
+where cmd >nul 2>nul || ( echo cmd.exe bulunamadi. Lutfen README.md'deki sorun giderme bolumune bakin. & pause & exit /b 1 )
 title Administrator: stop_all
 REM Deneysel: uvicorn/react calisan pencereleri kapatmaya calisir.
 for /f "tokens=2 delims==;" %%i in ('wmic process where "CommandLine like '%%uvicorn main:app%%'" get ProcessId /value ^| find "="') do taskkill /PID %%i /F >nul 2>&1


### PR DESCRIPTION
## Summary
- guard every batch script with a `where cmd` check so they fail fast when `cmd.exe` is missing
- add troubleshooting note in README about missing `cmd.exe`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0461e037083339f3b6c500eaf5f30