### PR TITLE
Avoid deprecated pydantic dict usage

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -195,7 +195,8 @@ async def list_contacts():
     """Return contacts of users from joined chats."""
     cfg = load_cfg()
     try:
-        data = await contacts.list_contacts(cfg.dict(), {})
+        cfg_dict = cfg.model_dump() if hasattr(cfg, "model_dump") else cfg.dict()
+        data = await contacts.list_contacts(cfg_dict, {})
     except PermissionError as exc:
         raise HTTPException(status_code=401, detail=str(exc))
     return data.get("items", [])


### PR DESCRIPTION
## Summary
- replace cfg.dict() with cfg.model_dump() in contacts endpoint to avoid Pydantic deprecation warning

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0474f1ed08333b220df0a80a24a5b